### PR TITLE
rename github package repository url

### DIFF
--- a/php-build.bash
+++ b/php-build.bash
@@ -85,7 +85,7 @@ repo_without_org=$(echo "$GITHUB_REPOSITORY" | sed "s/[^\/]*\///")
 # Note: The GITHUB_REPOSITORY is the repo where the action is running, nothing
 # to do with the php-actions organisation. This means that the image is pushed
 # onto a user's Github profile (currently not shared between other users).
-docker_tag="docker.pkg.github.com/${GITHUB_REPOSITORY}/php-actions_${base_repo}_${repo_without_org}:${dockerfile_unique}"
+docker_tag="ghcr.io/${GITHUB_REPOSITORY}/php-actions_${base_repo}_${repo_without_org}:${dockerfile_unique}"
 echo "$docker_tag" > ./docker_tag
 
 # Attempt to pull the existing Docker image, if it exists. If the image has


### PR DESCRIPTION
Action that was working until now has stopped working, so I will issue a PR.

The GitHub Package URL has changed.
https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-docker-registry

The previous URL will have a status of 404 and an error will occur when pushing.

```
  The push refers to repository [docker.pkg.github.com/org/reponame/php-actions_phpstan_reponame]
  c4b804e7db80: Preparing
  74c168eb936c: Preparing
  a66a3e1d7138: Preparing
  616c1c7e3991: Preparing
  d334afe9b155: Preparing
  0ac5f946b6a5: Preparing
  744437e91ddb: Preparing
  49a1a2a80ba6: Preparing
  cd3f5d78e589: Preparing
  994393dc58e7: Preparing
  0ac5f946b6a5: Waiting
  744437e91ddb: Waiting
  49a1a2a80ba6: Waiting
  cd3f5d78e589: Waiting
  994393dc58e7: Waiting
  denied: permission_denied: write_package
```